### PR TITLE
Updating sim_post to sample more efficiently

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -4,9 +4,9 @@
 # https://community.rstudio.com/new-topic?category=Package%20development&tags=github-actions
 on:
   push:
-    branches: [master,staging]
+    branches: [main,staging]
   pull_request:
-    branches: [master,staging]
+    branches: [main,staging]
 
 name: R-CMD-check
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,9 @@ Imports:
     rnaturalearth,
     traipse,
     terra,
-    trip (>= 1.10.0)
+    trip (>= 1.10.0),
+    Matrix,
+    stats
 LinkingTo: TMB, RcppEigen
 Suggests: 
     testthat,

--- a/R/sim_post.R
+++ b/R/sim_post.R
@@ -1,3 +1,15 @@
+## Taken from RTMB:::rgmrf0
+# Sampling from mean zero multivariate Gaussian using sparse precision matrix Q.
+# This is much more efficient if precision in sparse but Covariance is dense.
+rgmrf0 <- function (n, Q) 
+{
+  L <- Matrix::Cholesky(Q, super = TRUE, LDL = FALSE)
+  u <- matrix(stats::rnorm(ncol(L) * n), ncol(L), n)
+  u <- Matrix::solve(L, u, system = "Lt")
+  u <- Matrix::solve(L, u, system = "Pt")
+  as.matrix(u)
+}
+
 ##' @title simulate from the posterior of a \code{ssm} fit.
 ##'
 ##' @description simulates track locations from the joint precision matrix of a 
@@ -47,22 +59,38 @@ sim_post <- function(x,
   
     ## re-gen sdreport w jnt prec matrix
     sdp <- sdreport(x$ssm[[k]]$tmb, getJointPrecision = TRUE)
-  
+    
     ## get random parameters & subset to just locations
     reMu <- sdp$par.random
     reMu <- reMu[names(reMu) %in% X]
-
+    
+    # Not inverting full precision and sampling using rmvnorm on margin
+    # but sampling full parameter vector (including fixed effects) using
+    # RTMB:::rgmrf0 (which is efficient when precision is sparse) and then only keeping the desired margin
+    
+    jp <- sdp$jointPrecision # keeping this sparse
+    
+    # directly sample using sparse joint precision
+    samples <- rgmrf0(reps, jp) # no mean
+    sel <- rownames(jp) %in% X # selector variable
+    
+    # initialise with posterior mode
+    rtracks <- matrix(rep(reMu, reps), nrow = reps, ncol = length(reMu), byrow = TRUE)
+    
+    # add random sampled deviations (only desired margin using sel)
+    rtracks <- rtracks + t(samples[sel, , drop = FALSE])
+    
     ## use full joint prec matrix
-    jp <- as.matrix(sdp$jointPrecision)
-    muCov <- solve(jp) ## matrix inverse, 1/prec = varcov
+    # jp <- as.matrix(sdp$jointPrecision)
+    # muCov <- solve(jp) ## matrix inverse, 1/prec = varcov
     ## subset to just the location covars after inversion
-    muCov <- muCov[rownames(muCov) %in% X, colnames(muCov) %in% X]
+    # muCov <- muCov[rownames(muCov) %in% X, colnames(muCov) %in% X]
     
     # simulate
-    rtracks <- mvtnorm::rmvnorm(reps,
-                                mean = reMu,
-                                sigma = muCov,
-                                checkSymmetry = FALSE)
+    # rtracks <- mvtnorm::rmvnorm(reps,
+    #                             mean = reMu,
+    #                             sigma = muCov,
+    #                             checkSymmetry = FALSE)
     
     ## what are we simulating? fitted or predicted locations?
     ## use obs index to subset simulated locs - do after sim so

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,7 +21,6 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![aniMotum status badge](https://ianjonsen.r-universe.dev/badges/aniMotum)](https://ianjonsen.r-universe.dev)
-[![Coverage status](https://codecov.io/gh/ianjonsen/aniMotum/branch/main/graph/badge.svg)](https://codecov.io/github/ianjonsen/aniMotum?branch=main)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7425388.svg)](https://doi.org/10.5281/zenodo.7425388)
 ![R-CMD-check](https://github.com/ianjonsen/aniMotum/actions/workflows/check-full.yaml/badge.svg?branch=main) 
 <!-- badges: end -->

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 [![aniMotum status
 badge](https://ianjonsen.r-universe.dev/badges/aniMotum)](https://ianjonsen.r-universe.dev)
-[![Coverage
-status](https://codecov.io/gh/ianjonsen/aniMotum/branch/main/graph/badge.svg)](https://codecov.io/github/ianjonsen/aniMotum?branch=main)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7425388.svg)](https://doi.org/10.5281/zenodo.7425388)
 ![R-CMD-check](https://github.com/ianjonsen/aniMotum/actions/workflows/check-full.yaml/badge.svg?branch=main)
 <!-- badges: end -->


### PR DESCRIPTION
The original version of sim_post converts the sparse joint precision matrix to dense,  then uses a dense solve and samples using mvtnorm::rmvnorm. This is extremely memory-intensive for larger data sets, even becoming prohibitive at some point.

We can exploit the sparsity pattern in the joint precision and sample without ever inverting using RTMB's rgmrf0. This is much faster and much lighter on memory, scaling well with increasing data sizes.

Note: Vignette Track_simulation states "A future version will include the option to incorporate uncertainty in the SSM movement parameters." But both versions use the full joint precision, so should already account for that.